### PR TITLE
UIリニューアルでColorStyleへの追加があったためAssets対応

### DIFF
--- a/BuyByFriends/Assets.swift
+++ b/BuyByFriends/Assets.swift
@@ -25,13 +25,18 @@ internal typealias AssetImageTypeAlias = ImageAsset.Image
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
 internal enum Asset {
   internal enum Colors {
+    internal static let alert = ColorAsset(name: "Colors/alert")
     internal static let beige = ColorAsset(name: "Colors/beige")
     internal static let chromeYellow = ColorAsset(name: "Colors/chromeYellow")
     internal static let jetBlack = ColorAsset(name: "Colors/jetBlack")
     internal static let lightGray = ColorAsset(name: "Colors/lightGray")
+    internal static let messageYellow = ColorAsset(name: "Colors/messageYellow")
     internal static let orange = ColorAsset(name: "Colors/orange")
+    internal static let secondText = ColorAsset(name: "Colors/secondText")
     internal static let silver = ColorAsset(name: "Colors/silver")
     internal static let stormGreen = ColorAsset(name: "Colors/stormGreen")
+    internal static let textLink = ColorAsset(name: "Colors/textLink")
+    internal static let thirdText = ColorAsset(name: "Colors/thirdText")
     internal static let white = ColorAsset(name: "Colors/white")
   }
   internal enum Icons {

--- a/BuyByFriends/Assets.xcassets/Colors/alert.colorset/Contents.json
+++ b/BuyByFriends/Assets.xcassets/Colors/alert.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x44",
+          "green" : "0x39",
+          "red" : "0xC7"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BuyByFriends/Assets.xcassets/Colors/messageYellow.colorset/Contents.json
+++ b/BuyByFriends/Assets.xcassets/Colors/messageYellow.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.150",
+          "blue" : "0x00",
+          "green" : "0xD6",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BuyByFriends/Assets.xcassets/Colors/secondText.colorset/Contents.json
+++ b/BuyByFriends/Assets.xcassets/Colors/secondText.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7B",
+          "green" : "0x67",
+          "red" : "0x6E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BuyByFriends/Assets.xcassets/Colors/textLink.colorset/Contents.json
+++ b/BuyByFriends/Assets.xcassets/Colors/textLink.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xAA",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BuyByFriends/Assets.xcassets/Colors/thirdText.colorset/Contents.json
+++ b/BuyByFriends/Assets.xcassets/Colors/thirdText.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA8",
+          "green" : "0x91",
+          "red" : "0x8A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
# 内容
タイトルの通りです〜！
これでFigmaにあるColorStyle全てが
`.foregroundColor(Asset.Colors.jetBlack.swiftUIColor)`
って感じでって使えるはずです🙌

![image](https://github.com/Koda-ooo/buybyFriends/assets/42166363/b32fe7ba-666d-4d89-8dac-a923ce25ce85)
